### PR TITLE
Added a check to test whether the empty-game.zip file exists

### DIFF
--- a/source/dash/cli/commands.d
+++ b/source/dash/cli/commands.d
@@ -43,15 +43,21 @@ class CreateCommand : Command
     override void execute( Project project )
     {
         import std.file, std.path, std.zip, std.stream, std.algorithm;
+        import std.stdio: writeln;
+
+        // Check that the empty-game.zip file exists
+        string emptyGameLocation = thisExePath.dirName.buildNormalizedPath( "empty-game.zip" );
+        if ( !exists(emptyGameLocation)) {
+            writeln("Can't access ", emptyGameLocation);
+            return;
+        }
 
         // If the project folder doesn't exist, create it.
         if( !project.directory.exists() )
             project.directory.mkdirRecurse();
 
-        // Unzip empty game to new folder.
-        auto zr = new ZipArchive( thisExePath.dirName.buildNormalizedPath( "empty-game.zip" ).read() );
-
         // Extract the empty-game.zip template.
+        auto zr = new ZipArchive( emptyGameLocation.read() );
         foreach( ArchiveMember de; zr.directory )
         {
             // Ignore folders.


### PR DESCRIPTION
This one tripped me up when using it. I didn't realise that I needed to move the empty-game.zip to /usr/bin as well so I ended up getting an unreadable error message. This just creates a cleaner error message. 

There were a few other error checking measures that I wanted to implement but file IO (and even attribute checking) is rather platform specific so I didn't really feel comfortable implementing them in a cross platform piece of software.
